### PR TITLE
fix: Rock disappearing bug on Challenge3

### DIFF
--- a/Assets/Scripts/Waypoints/Obstacle.cs
+++ b/Assets/Scripts/Waypoints/Obstacle.cs
@@ -135,8 +135,19 @@ public class Obstacle : MonoBehaviour
             }else{
                 ResetPosition();
             }
-            
+
         }
-        
+
+    }
+
+    public void FixedUpdate()
+    {
+        if (transform.position.y < -5.0) {
+            if (is_stage3) {
+                ResetRandomAndForce(Target);
+            } else {
+                ResetPosition();
+            }
+        }
     }
 }

--- a/Assets/Scripts/Waypoints/Obstacle.cs
+++ b/Assets/Scripts/Waypoints/Obstacle.cs
@@ -135,9 +135,7 @@ public class Obstacle : MonoBehaviour
             }else{
                 ResetPosition();
             }
-
         }
-
     }
 
     public void FixedUpdate()


### PR DESCRIPTION
The rocks occasionally jump out of the course, disappearing forever. This commit adds a check that checks that the position of the rock is never under `-5.0`.